### PR TITLE
Implement chain install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@
 
 ## Usage
 #### Commands
-- install
+- install [-chain|-c]
   + vimrc
   + zshrc
   + gitconfig
@@ -37,6 +37,7 @@
       "name": "vimrc", // <- install argument name
       "input": "/vim/.vimrc", // <- ex: https://github.com/account/repository/blob/master/vim/.vimrc
       "output": "~/.vimrc" // <- install path
+      "chain": ["ideavimrc", "xvimrc"]
     }
   ]
 }

--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,10 @@
     {
       "name": "vimrc",
       "input": "/vim/.vimrc",
-      "output": "~/.vimrc"
+      "output": "~/.vimrc",
+      "chain": [
+        "ideavimrc", "xvimrc"
+      ]
     },
     {
       "name": "zshrc",

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -25,18 +25,28 @@ impl<'a> Install<'a> {
             .arg(
                 Arg::with_name("rc").multiple(true)
             )
+            .arg(
+                Arg::with_name("chain")
+                    .help("chain install")
+                    .short("c")
+                    .long("chain")
+            )
     }
 
     pub fn execute(&self, matches: &ArgMatches) {
-        if let Some(dotfile) = matches.values_of("rc") {
-            dotfile
-                .into_iter()
-                .for_each(|dotfile| {
-                    DotfilesManager::new().sync(dotfile);
-                    self.chain(dotfile);
-                })
+        if let Some(mut values) = matches.values_of("rc") {
+            if let Some(dotfile) = values.next() {
+                self.install(dotfile, matches.is_present("chain"));
+            }
         } else {
             println!("install command required arguments.");
+        }
+    }
+
+    fn install(&self, dotfile: &str, is_chain: bool) {
+        DotfilesManager::new().sync(dotfile);
+        if is_chain {
+            self.chain(dotfile);
         }
     }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -28,12 +28,26 @@ impl<'a> Install<'a> {
     }
 
     pub fn execute(&self, matches: &ArgMatches) {
-        if let Some(rcs) = matches.values_of("rc") {
-            rcs.into_iter().for_each(|rc| {
-                DotfilesManager::new().sync(rc);
-            })
+        if let Some(dotfile) = matches.values_of("rc") {
+            dotfile
+                .into_iter()
+                .for_each(|dotfile| {
+                    DotfilesManager::new().sync(dotfile);
+                    self.chain(dotfile);
+                })
         } else {
             println!("install command required arguments.");
         }
+    }
+
+    fn chain(&self, dotfile: &str) {
+        let manager = DotfilesManager::new();
+        manager.find_dotfile(dotfile)
+            .into_iter()
+            .flat_map(|dotfile| dotfile.chain)
+            .next()
+            .into_iter()
+            .flat_map(|chain| chain)
+            .for_each(|dotfile| manager.sync(&dotfile))
     }
 }

--- a/src/dotfiles/dotfiles_manager.rs
+++ b/src/dotfiles/dotfiles_manager.rs
@@ -31,7 +31,7 @@ impl<'a> DotfilesManager<'a> {
             .map_or("".to_string(), |dotfile| dotfile.output)
     }
 
-    fn find_dotfile(&self, file: &str) -> Option<Dotfile> {
+    pub fn find_dotfile(&self, file: &str) -> Option<Dotfile> {
         SettingsRepository.load().dotfiles
             .into_iter()
             .filter(|dotfile| dotfile.name == file.to_string())

--- a/src/settings/settings.rs
+++ b/src/settings/settings.rs
@@ -12,5 +12,6 @@ pub struct Settings {
 pub struct Dotfile {
     pub name: String,
     pub input: String,
-    pub output: String
+    pub output: String,
+    pub chain: Option<Vec<String>>
 }


### PR DESCRIPTION
resolve: #3 

## Usage
Chain mode is install configured chain dotfiles.
```
❯ dotman install -c vimrc
```

### ex: settings.json.
 When chain mode, install vimrc, ideavimrc, and xvimrc.
```
{
  ...
  "dotfiles": [
    {
      "name": "vimrc",
      "input": "/vim/.vimrc",
      "output": "~/.vimrc",
      "chain": ["ideavimrc", "xvimrc"]
    }
  ]
}
```